### PR TITLE
Add new flag and functionality to support checksum digest

### DIFF
--- a/docs/samples/digestdir/digest.tsv
+++ b/docs/samples/digestdir/digest.tsv
@@ -1,0 +1,2 @@
+ladee_1100.xml 12345
+gentleman.xml 67890

--- a/docs/samples/digestdir/subdir/digest.tsv
+++ b/docs/samples/digestdir/subdir/digest.tsv
@@ -1,0 +1,1 @@
+ladee_spacecraft_rev1_2.xml	43210


### PR DESCRIPTION
An attempt at #4 (adds `--digestdir` command line option in order to use pre-computed digests)

There are a number of assumptions here that'll probably need revisiting:

- Issue #4 says to add a true/false flag for checksum manifest; skipping that since it's implied by providing a flag for the manifest base directory
- Since we're providing a directory and not a single file, we're assuming that the directory contains a tree of possible manifest files
- Assuming manifest files are named `manifest.tsv`; all of them are read into memory
- Treating them as tab separated values of "filename" TAB "digest" (checksum)
- They're actually whitespace separated values
- No commenting or other syntax specified for them

The `docs/samples` directory now includes a sample tree of `manifest.tsv` files.

NOTE: These changes were rebased in internal repo so functionality will most likely need to be modified and tested.