### PR TITLE
Resolve #137

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 # Items for Git to ignore
 
 # Python build, virtual environments, and buildouts
+.venv
 venv
 __pycache__/
 dist/

--- a/src/pds2/aipgen/registry.py
+++ b/src/pds2/aipgen/registry.py
@@ -182,7 +182,7 @@ def _getcollections(apiclient: pds.api_client.ApiClient, lidvid: str, allcollect
                 results = bcapi.collections_of_a_bundle_latest(
                     lidvid, start=start, limit=_apiquerylimit, fields=_fields
                 )
-
+            if len(results.data) == 0: return
             start += len(results.data)
             for i in results.data:
                 yield i
@@ -198,7 +198,7 @@ def _getproducts(apiclient: pds.api_client.ApiClient, lidvid: str):
         try:
             _logger.debug("⚙️ Asking ``products_of_a_collection`` for %s at %d limit %d", lidvid, start, _apiquerylimit)
             results = cpapi.products_of_a_collection(lidvid, start=start, limit=_apiquerylimit, fields=_fields)
-
+            if len(results.data) == 0: return
             start += len(results.data)
             for i in results.data:
                 yield i


### PR DESCRIPTION
## 🗒️ Summary

Merge this to resolve #137 by handling the case—and why didn't this come up before?—when there are zero products in a collection. As an added bonus, we also handle the case of zero collections in a bundle.

## ⚙️ Test Data and/or Report
```
kelly@mirasol deep-archive % .venv/bin/pds-deep-registry-archive --url https://pds.nasa.gov/api/search/1.0 --debug --site PDS_ATM urn:nasa:pds:mer1_rmc::1.0

INFO 👟 PDS Deep Registry-based Archive, version 1.1.2
DEBUG 💢 command line args = Namespace(loglevel=10, include_latest_collection_only=False, url='https://pds.nasa.gov/api/search/1.0', site='PDS_ATM', bundle='urn:nasa:pds:mer1_rmc::1.0')
DEBUG 🤔 Comprehending the registry at https://pds.nasa.gov/api/search/1.0 for urn:nasa:pds:mer1_rmc::1.0
DEBUG ⚙️ Asking ``bundle_by_lidvid`` for urn:nasa:pds:mer1_rmc::1.0
DEBUG ⚙️ Asking ``collections_of_a_bundle`` for urn:nasa:pds:mer1_rmc::1.0 at 0 limit 50
DEBUG ⚙️ Asking ``products_of_a_collection`` for urn:nasa:pds:mer1_rmc:document::1.0 at 0 limit 50
DEBUG ⚙️ Asking ``products_of_a_collection`` for urn:nasa:pds:mer1_rmc:data::1.0 at 0 limit 50
DEBUG ⚙️ Asking ``products_of_a_collection`` for urn:nasa:pds:mer1_rmc:data::1.0 at 50 limit 50
DEBUG ⚙️ Asking ``products_of_a_collection`` for urn:nasa:pds:mer1_rmc:miscellaneous::1.0 at 0 limit 50
DEBUG ⚙️ Asking ``products_of_a_collection`` for urn:nasa:pds:mer1_rmc:miscellaneous::1.0 at 1 limit 50
DEBUG ⚙️ Asking ``collections_of_a_bundle`` for urn:nasa:pds:mer1_rmc::1.0 at 3 limit 50
DEBUG ⚙️ Creating AIP for urn:nasa:pds:mer1_rmc::1.0
DEBUG ⏲ Wrote 100 entries into the checksum manifest mer1_rmc_v1.0_20230118_checksum_manifest_v1.0.tab
INFO 📄 Wrote AIP checksum manifest mer1_rmc_v1.0_20230118_checksum_manifest_v1.0.tab with 110 entries
DEBUG ⚙️ Writing AIP transfer manifest to mer1_rmc_v1.0_20230118_transfer_manifest_v1.0.tab
DEBUG ⏲ Wrote 100 entries into the transfer manifest mer1_rmc_v1.0_20230118_transfer_manifest_v1.0.tab
INFO 📄 Wrote AIP transfer manifest mer1_rmc_v1.0_20230118_transfer_manifest_v1.0.tab with 110 entries
DEBUG 🏷  Writing AIP label to mer1_rmc_v1.0_20230118_aip_v1.0.xml
INFO 📄 Wrote label for them both: mer1_rmc_v1.0_20230118_aip_v1.0.xml
DEBUG ⚙️ Creating SIP for urn:nasa:pds:mer1_rmc::1.0 (title MER1 Rover Motion Counter Data Bundle) for site PDS_ATM
DEBUG ⏲ Wrote 100 entries into the submission info file mer1_rmc_v1.0_20230118_sip_v1.0.tab
INFO 📄 Wrote SIP mer1_rmc_v1.0_20230118_sip_v1.0.tab with 110 entries
INFO 📄 Wrote label for SIP: mer1_rmc_v1.0_20230118_sip_v1.0.xml
DEBUG 🏷  Writing SIP label to <_io.BufferedWriter name='mer1_rmc_v1.0_20230118_sip_v1.0.xml'>
INFO 👋 Thanks for using this program! Bye!
kelly@mirasol deep-archive % echo 😎
😎
kelly@mirasol deep-archive % 

Saving session...
...saving history...truncating history files...
...completed.
```

## ♻️ Related Issues

- #137 

