### PR TITLE
Updated Jenkins build to use Expo registry and insight_rad bundle

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline {
                 // 🔮 In the future, we'll also want to look at the generated output files and ensure
                 // they contain correct data. But right now, pagination is broken in the server so we
                 // can't even get output files, so we'll just go by exit status.
-                sh ".venv/bin/pds-deep-registry-archive --debug --site PDS_ATM urn:nasa:pds:mer1_navcam_sci_calibrated::1.0"
+                sh ".venv/bin/pds-deep-registry-archive --debug --url http://localhost:8080 --site PDS_ATM urn:nasa:pds:insight_rad::2.1"
             }
         }
     }


### PR DESCRIPTION
## 🗒️ Summary

Merge this to make [PDS Jenkins](https://pds-jenkins.jpl.nasa.gov/) successfully build and test the Deep Archive against the Jenkins-built Expo Registry. All this does really is override the Deep Archive with the `--url` option to point to the local Expo Registry and change the bundle from `mer1_navcam_sci` (which isn't available in the test data loaded into the Expo Registry) to `insight_rad` (which is).

## ⚙️ Test Data and/or Report

See https://pds-jenkins.jpl.nasa.gov/job/Deep%20Archive/6/

## ♻️ Related Issues

- #147 
