### PR TITLE
Fixes false positive in secret detection against baseline due to config change

### DIFF
--- a/.github/workflows/secrets-detection.yaml
+++ b/.github/workflows/secrets-detection.yaml
@@ -46,6 +46,7 @@ jobs:
                     # find the secrets in the repository
                     detect-secrets scan --disable-plugin AbsolutePathDetectorExperimental --baseline .secrets.new \
                         --exclude-files '\.secrets..*' \
+                        --exclude-files '\.pre-commit-config\.yaml' \
                         --exclude-files '\.git.*' \
                         --exclude-files '\.mypy_cache' \
                         --exclude-files '\.pytest_cache' \

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -119,7 +119,7 @@
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
         "\\.secrets..*",
-        "\\.pre-commit-config.yaml",
+        "\\.pre-commit-config\\.yaml",
         "\\.git.*",
         "\\.mypy_cache",
         "\\.pytest_cache",


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

The problem wasn't that a new secret suddenly appeared. Instead, it was that the `.pre-commit-config.yaml` wasn't included in the baseline configuration which resulted in a diff when the GitHub Action ran. The GitHub Action from SLIM is a bit primitive: it treats _any diff_ as a new secret. In this case, the diff was a difference in config, not in secrets.

This also properly escapes the `.` in the regex for excluded files named `.pre-commit-config.yaml`.

## ⚙️ Test Data and/or Report

See https://github.com/nasa-pds-engineering-node/deep-archive/actions/runs/7035037799

## ♻️ Related Issues

- [software-issues-repo#55](https://github.com/NASA-PDS/software-issues-repo/issues/55)
