### PR TITLE
Use full uniform resource names with generated SIPs and AIPs from PDS Registry

### DIFF
--- a/src/pds2/aipgen/registry.py
+++ b/src/pds2/aipgen/registry.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Copyright © 2021 California Institute of Technology ("Caltech").
+# Copyright © 2021–2024 California Institute of Technology ("Caltech").
 # ALL RIGHTS RESERVED. U.S. Government sponsorship acknowledged.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -131,6 +131,16 @@ def _deurnlidvid(lidvid: str) -> tuple[str, str]:
     """
     lid, vid = lidvid.split("::")
     return lid.split(":")[-1], vid
+
+
+def _splitlidvid(lidvid: str) -> tuple[str, str]:
+    """Split a LIDVID into a LID and VID.
+
+    Given a PDS ``lidvid`` as a Uniform Resource Name such as ``urn:nasa:pds:whatever::1.0``,
+    transform it to a double of ``urn:nasa:pds:whatever`` and ``1.0``.
+    """
+    lid, vid = lidvid.split("::")
+    return lid, vid
 
 
 def _makefilename(lidvid: str, ts: datetime, kind: str, ext: str) -> str:
@@ -372,8 +382,8 @@ def _writeaip(bundlelidvid: str, prefixlen: int, bac: dict, ts: datetime) -> str
     tmfn = _makefilename(bundlelidvid, ts, "transfer_manifest", PDS_TABLE_FILENAME_EXTENSION)
     cmmd5, cmsize, cmnum = _writechecksummanifest(cmfn, prefixlen, bac)
     tmmd5, tmsize, tmnum = _writetransfermanifest(tmfn, prefixlen, bac)
-    lid, vid = _deurnlidvid(bundlelidvid)
     labelfn = _makefilename(bundlelidvid, ts, "aip", PDS_LABEL_FILENAME_EXTENSION)
+    lid, vid = _splitlidvid(bundlelidvid)
     writeaiplabel(labelfn, f"{lid}_v{vid}", lid, vid, cmfn, cmmd5, cmsize, cmnum, tmfn, tmmd5, tmsize, tmnum, ts)
     _logger.info("📄 Wrote label for them both: %s", labelfn)
     return cmmd5
@@ -405,7 +415,7 @@ def _writesip(bundlelidvid: str, bac: dict, title: str, site: str, ts: datetime,
     labelfn = _makefilename(bundlelidvid, ts, "sip", PDS_LABEL_FILENAME_EXTENSION)
     _logger.info("📄 Wrote label for SIP: %s", labelfn)
     with open(labelfn, "wb") as o:
-        lid, vid = _deurnlidvid(bundlelidvid)
+        lid, vid = _splitlidvid(bundlelidvid)
         writesiplabel(lid, vid, title, hashish.hexdigest(), size, count, "MD5", sipfn, site, o, cmmd5, ts)
 
 


### PR DESCRIPTION
## 🗒️ Summary

Use full uniform resource names when generating SIPs and AIPs from PDS Registry. When "validate" is run on these files, the invalid [LIDVID error](https://github.com/NASA-PDS/deep-archive/issues/155) now goes away.

The issue of CRLF line endings [is being addressed separately](https://github.com/NASA-PDS/validate/issues/820).

## ⚙️ Test Data and/or Report

Not necessary thanks to pre-commit hooks, but see also this:
```

PDS Validate Tool Report

Configuration:
   Version     3.5.0-SNAPSHOT
   Date        2024-02-01T19:12:26Z

Parameters:
   Targets                      [file:/Users/kelly/Desktop/CRLF/magellan_gxdr_v1.0_20240201_aip_v1.0.xml, file:/Users/kelly/Desktop/CRLF/magellan_gxdr_v1.0_20240201_sip_v1.0.xml]
   Severity Level               WARNING
…
Product Level Validation Results

  FAIL: file:/Users/kelly/Desktop/CRLF/magellan_gxdr_v1.0_20240201_aip_v1.0.xml
    Begin Content Validation: file:/Users/kelly/Desktop/CRLF/magellan_gxdr_v1.0_20240201_transfer_manifest_v1.0.tab
      ERROR  [error.table.missing_CRLF]   data object transfer manifest or index 1, record 1: Record does not end in carriage-return line feed.
      ERROR  [error.table.missing_CRLF]   data object transfer manifest or index 1, record 2: Record does not end in carriage-return line feed.
      ERROR  [error.table.missing_CRLF]   data object transfer manifest or index 1, record   PASS: file:/Users/kelly/Desktop/CRLF/magellan_gxdr_v1.0_20240201_sip_v1.0.xml
…
        2 product validation(s) completed

Summary:

  2 product(s)
  109 error(s)
  0 warning(s)

  Product Validation Summary:
    1          product(s) passed
    1          product(s) failed
    0          product(s) skipped
    2          product(s) total

  Referential Integrity Check Summary:
    0          check(s) passed
    0          check(s) failed
    0          check(s) skipped
    0          check(s) total

  Message Types:
    109          error.table.missing_CRLF

End of Report
Completed execution in 10762 ms
```

## ♻️ Related Issues

- #155 
