### PR TITLE
In registry-based transfer manifests, make second column 255 characters (not 256)

### DIFF
--- a/src/pds2/aipgen/registry.py
+++ b/src/pds2/aipgen/registry.py
@@ -358,7 +358,7 @@ def _writetransfermanifest(fn: str, prefixlen: int, bac: dict) -> tuple[str, int
     with open(fn, "wb") as o:
         for lidvid, files in bac.items():
             for f in files:
-                entry = f"{lidvid:255}/{f.url[prefixlen:]:255}\r\n".encode("utf-8")
+                entry = f"{lidvid:255}/{f.url[prefixlen:]:254}\r\n".encode("utf-8")  # 254 because we hard-code the /
                 o.write(entry)
                 hashish.update(entry)
                 size += len(entry)


### PR DESCRIPTION
## 🗒️ Summary

The line lengths of transfer manifests generated by the Deep Archive on local labels should all be 511 (✅) characters (not including line terminators). However, @jordanpadams reported in #158 that the line lengths of transfer manifests were 512 (❌) characters. They should be identical.

This patch repairs the problem.

## ⚙️ Test Data and/or Report

```console
$ pds-deep-registry-archive --quiet --site PDS_GEO urn:nasa:pds:magellan_gxdr::1.0
$ awk '{print length}' magellan_gxdr_v1.0_*_transfer_manifest_v1.0.tab | uniq -c
 109 511
$ echo \405
✅
```

## ♻️ Related Issues

- #158 
