### PR TITLE
Add compatibility with PDS API version 1.4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,9 +55,11 @@ install_requires =
     lxml           == 4.9.0  # Must be 4.9.0 for Windows compatibility with prebuilt https://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml
     zope.component ~= 5.0.1
     zope.interface ~= 5.4.0
-    pds.api-client ~= 1.1.0
+    requests       ~= 2.31.0
 # It's a bummer we can't use the "pds" namespace and have to use "pds2".
 # See https://github.com/NASA-PDS/pds-api-client/issues/7 for why.
+# 2024-02-22: Actually since dumping pds.api-client for Python Requests,
+# we could move back to "pds"!
 namespace_packages   = pds2
 zip_safe             = True
 include_package_data = True
@@ -110,6 +112,7 @@ dev =
     pytest-watch        == 4.2.0   # Automatic testing every time you save a file
     pytest-xdist        == 2.4.0   # You got multiple cores, right?
     pre-commit          == 2.15.0  # Auto-run checks on every commit
+    types-requests      ~= 2.31.0.20240218
 
 
 # Flake8


### PR DESCRIPTION
## 🗒️ Summary

Merge this to make the Deep Archive compatible with PDS API version 1.4.0. Note that this is a backwards-incompatible change and will no longer support earlier versions of the PDS API.

## ⚙️ Test Data and/or Report

With earlier PDS API and older Deep Archive:
```console
$ pds-deep-registry-archive --version
pds-deep-registry-archive 1.1.4
$ pds-deep-registry-archive  --quiet --site PDS_ATM urn:nasa:pds:magellan_gxdr::1.0
$ wc -l magellan_gxdr_v1.0_20240222_*
      84 magellan_gxdr_v1.0_20240222_aip_v1.0.xml
     109 magellan_gxdr_v1.0_20240222_checksum_manifest_v1.0.tab
     109 magellan_gxdr_v1.0_20240222_sip_v1.0.tab
      89 magellan_gxdr_v1.0_20240222_sip_v1.0.xml
     109 magellan_gxdr_v1.0_20240222_transfer_manifest_v1.0.tab
     500 total
```
With the 1.4.0 PDS API (currently hosted at `https://pds.nasa.gov/api/search-en-gamma/1`):
```console
$ pds-deep-registry-archive --version
pds-deep-registry-archive 1.2.0
$ pds-deep-registry-archive  --quiet --url https://pds.nasa.gov/api/search-en-gamma/1 --site PDS_ATM urn:nasa:pds:magellan_gxdr::1.0
$ wc -l magellan_gxdr_v1.0_20240222_*
      84 magellan_gxdr_v1.0_20240222_aip_v1.0.xml
     109 magellan_gxdr_v1.0_20240222_checksum_manifest_v1.0.tab
     109 magellan_gxdr_v1.0_20240222_sip_v1.0.tab
      89 magellan_gxdr_v1.0_20240222_sip_v1.0.xml
     109 magellan_gxdr_v1.0_20240222_transfer_manifest_v1.0.tab
     500 total
```

## ♻️ Related Issues

- #159 
