### PR TITLE
Work around registry URLs with multiple slashes by outputting paths with single slashes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -148,14 +148,35 @@
         "filename": "src/pds2/aipgen/tests/test_utils.py",
         "hashed_secret": "10a34637ad661d98ba3344717656fcc76209c2f8",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 49
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/pds2/aipgen/tests/test_utils.py",
         "hashed_secret": "67a74306b06d0c01624fe0d0249a570f4d093747",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 50
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/pds2/aipgen/tests/test_utils.py",
+        "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
+        "is_verified": false,
+        "line_number": 169
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/pds2/aipgen/tests/test_utils.py",
+        "hashed_secret": "66ed46e8b325ac0c7982bd070c132bff14093bc3",
+        "is_verified": false,
+        "line_number": 169
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/pds2/aipgen/tests/test_utils.py",
+        "hashed_secret": "fe5c714e9a30a923a58dac84e0af313c7fb7c553",
+        "is_verified": false,
+        "line_number": 179
       }
     ],
     "test/data/insight_documents/urn-nasa-pds-insight_documents/document_hp3rad/release_notes.txt": [
@@ -204,5 +225,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-16T17:14:34Z"
+  "generated_at": "2024-04-19T15:04:19Z"
 }

--- a/src/pds2/aipgen/registry.py
+++ b/src/pds2/aipgen/registry.py
@@ -52,6 +52,7 @@ from .constants import PROVIDER_SITE_IDS
 from .sip import writelabel as writesiplabel
 from .utils import addbundlearguments
 from .utils import addloggingarguments
+from .utils import fixmultislashes
 
 
 # Constants
@@ -102,6 +103,16 @@ class _File:
 
     url: str
     md5: str
+
+    @classmethod
+    def make(cls, url, md5):
+        """Make a ``_File``, fixing issues with multi-slashes in ``url``.
+
+        Note that this allows us to keep the generated ctor from ``dataclass`` without
+        having to do weird things with ``__setattr__``. See https://dsh.re/f9fd7b for
+        more information.
+        """
+        return cls(fixmultislashes(url), md5)
 
 
 def _deurnlidvid(lidvid: str) -> tuple[str, str]:
@@ -179,9 +190,9 @@ def _addfiles(product: dict, bac: dict):
     if _propdataurl in props:  # Are there data files in the product?
         urls, md5s = props[_propdataurl], props[_propdatamd5]  # Get the URLs and MD5s of them
         for url, md5 in zip(urls, md5s):  # For each URL and matching MD5
-            files.add(_File(url, md5))  # Add it to the set
+            files.add(_File.make(url, md5))  # Add it to the set
     if _proplabelurl in props:  # How about the label itself?
-        files.add(_File(props[_proplabelurl][0], props[_proplabelmd5][0]))  # Add it too
+        files.add(_File.make(props[_proplabelurl][0], props[_proplabelmd5][0]))  # Add it too
     bac[lidvid] = files  # Stash for future use
 
 

--- a/src/pds2/aipgen/utils.py
+++ b/src/pds2/aipgen/utils.py
@@ -35,6 +35,8 @@ import os.path
 import re
 import sqlite3
 import urllib
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
 
 from lxml import etree
 from zope.interface import implementer
@@ -66,6 +68,19 @@ root directory.
 
 # Functions
 # ---------
+
+
+def fixmultislashes(url):
+    """Fix occurrences of multiple slashes in the given ``url``.
+
+    This addresses issue №162: where submission information packages would have double-
+    slashes in their paths, which leads to validation errors. Note that the upstream
+    problem is that the registry is loaded with examples of these bad paths. This is
+    a workaround.
+    """
+    scheme, netloc, path, params, query, fragment = urlparse(url)
+    path = re.sub(r'/{2,}', '/', path)
+    return urlunparse((scheme, netloc, path, params, query, fragment))
 
 
 def createschema(con):


### PR DESCRIPTION
## 🗒️ Summary

Merge this to workaround registry `file_ref` URLs that have double-slashes in them as reported in #162 and experience by [some users](https://github.com/NASA-PDS/operations/issues/476).

## ⚙️ Test Data and/or Report

Before:
```console
$ pds-deep-registry-archive --quiet --site PDS_ATM urn:nasa:pds:cassini_uvis_solarocc_beckerjarmak2023::1.0
$ egrep -c '//data' cassini_uvis_solarocc_beckerjarmak2023_v1.0_*_sip_v1.0.tab
86
```

After:
```console
$ pds-deep-registry-archive --quiet --site PDS_ATM urn:nasa:pds:cassini_uvis_solarocc_beckerjarmak2023::1.0
$ egrep -c '//data' cassini_uvis_solarocc_beckerjarmak2023_v1.0_*_sip_v1.0.tab
0
```

## ♻️ Related Issues

- #162 
- [NASA-PDS/operations#476](https://github.com/NASA-PDS/operations/issues/476)