### PR TITLE
Adjust some dependabot recommendations to actually work

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -96,18 +96,18 @@ dev =
     sphinx              == 4.2.0   # Documentation generation
     sphinx-rtd-theme    == 0.5.0   # Documentation theme
     sphinx-argparse     == 0.2.5   # I don't think we even use this
-    mypy-zope           == 0.3.2   # Type stubs for zope.interface
+    mypy-zope           == 1.0.5   # Type stubs for zope.interface
     types-pkg_resources == 0.1.3   # Type stubs for package introspection API
     lxml-stubs          == 0.5.1   # Type stubs for lxml, duh
     flake8              == 3.9.2   # Unquestioning adherence to coding stylees
     flake8-bugbear      == 21.9.1  # Ditto
     flake8-docstrings   == 1.6.0   # And check the docstrings too
     pep8-naming         == 0.12.1  # And even your function and variable names
-    mypy                == 0.910   # Do your type annotations actually work?
+    mypy                ~= 1.10.0  # Do your type annotations actually work?
     pydocstyle          == 6.1.1   # Do your docstrings look like everyone else's?
     coverage            == 5.5     # Does all your code get exercised?
     pytest              == 6.2.5   # Testing
-    pytest-cov          == 2.12.1  # pytest + coverage = pytest-cov
+    pytest-cov          == 5.0.0   # pytest + coverage = pytest-cov
     pytest-watch        == 4.2.0   # Automatic testing every time you save a file
     pytest-xdist        == 2.4.0   # You got multiple cores, right?
     pre-commit          == 2.15.0  # Auto-run checks on every commit

--- a/src/pds2/aipgen/registry.py
+++ b/src/pds2/aipgen/registry.py
@@ -174,7 +174,7 @@ def _getproducts(server_url: str, lidvid: str, allcollections=True) -> Iterator[
     params = {"sort": _searchkey, "limit": _apiquerylimit}
     while True:
         _logger.debug('Making request to %s with params %r', url, params)
-        r = requests.get(url, params=params)
+        r = requests.get(url, params=params)  # type: ignore
         matches = r.json()["data"]
         num_matches = len(matches)
         for i in matches:


### PR DESCRIPTION
## 🗒️ Summary

Dependabot recently came up with a suggested set of upgrades (mypy 0.910 → 1.11.2, mypy-zope 0.3.2 → 1.0.5, and pytest-cov 2.12.1 → 5.0.0), however in testing these not just work, they won't even install due to conflicts.

This PR presents a different set that upgrades the components in question, but also work.

## ⚙️ Test Data and/or Report

```
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check that executables have shebangs.................(no files to check)Skipped
Check for merge conflicts................................................Passed
Debug Statements (Python)................................................Passed
Check Yaml...........................................(no files to check)Skipped
Reorder python imports...................................................Passed
mypy.....................................................................Passed
flake8...................................................................Passed
Detect secrets...........................................................Passed
…
======================================= 19 passed, 16 skipped, 9 warnings in 0.28s =======================================
```

## ♻️ Related Issues

None; just addressing Dependabot's alerts