### PR TITLE
Fix 255-character padding in transfer manifests

### DIFF
--- a/src/pds2/aipgen/registry.py
+++ b/src/pds2/aipgen/registry.py
@@ -279,7 +279,7 @@ def _writetransfermanifest(fn: str, pathprefix: str, bac: dict) -> tuple[str, in
         for lidvid, files in bac.items():
             for f in files:
                 # We use [:254] because we hard code the ``/``:
-                entry = f"{lidvid:255}/{_urltocommonpath(f.url, pathprefix)[:254]}\r\n".encode("utf-8")
+                entry = f"{lidvid:255}/{_urltocommonpath(f.url, pathprefix):254}\r\n".encode("utf-8")
                 o.write(entry)
                 hashish.update(entry)
                 size += len(entry)


### PR DESCRIPTION
## 🗒️ Summary

Merge this to bring back padding the second column of transfer manifests to 255 characters.

## ⚙️ Test Data and/or Report
In addition to all the hooks passing, note the following:
```console
$ pds-deep-registry-archive --quiet --site PDS_SBN urn:nasa:pds:cassini_uvis_solarocc_beckerjarmak2023::1.0
$ validate --target cassini_uvis_solarocc_beckerjarmak2023_v1.0_*_aip_v1.0.xml

PDS Validate Tool Report

Configuration:
   Version     3.6.0-SNAPSHOT
   Date        2024-09-11T17:39:05Z

Parameters:
   Targets                      [file:/Users/kelly/Documents/Clients/JPL/PDS/Development/nasa-pds/deep-archive/cassini_uvis_solarocc_beckerjarmak2023_v1.0_20240911_aip_v1.0.xml]
   Severity Level               WARNING
   Recurse Directories          true
   File Filters Used            [*.xml, *.XML]
   Data Content Validation      on
   Product Level Validation     on
   Max Errors                   100000
   Registered Contexts File     /Users/kelly/Documents/Clients/JPL/PDS/Development/nasa-pds/deep-archive/validate/resources/registered_context_products.json



Product Level Validation Results

  PASS: file:/Users/kelly/Documents/Clients/JPL/PDS/Development/nasa-pds/deep-archive/cassini_uvis_solarocc_beckerjarmak2023_v1.0_20240911_aip_v1.0.xml
        1 product validation(s) completed

Summary:

  1 product(s)
  0 error(s)
  0 warning(s)

  Product Validation Summary:
    1          product(s) passed
    0          product(s) failed
    0          product(s) skipped
    1          product(s) total

  Referential Integrity Check Summary:
    0          check(s) passed
    0          check(s) failed
    0          check(s) skipped
    0          check(s) total


End of Report
Completed execution in 10230 ms
```


## ♻️ Related Issues

- #186 
