### PR TITLE
Add note to documentation regarding limitation of support for collections referencing multiple versions of a product

### DIFF
--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -184,6 +184,8 @@ include:
 As with ``pds-deep-archive``, you can also specify ``--include-latest-collection-only`` to select if you want just the latest version of LID-only collections in your deep archive versus the default behavior of **all** versions of them.
 
 
+
+
 PDS Delivery Checklist
 ----------------------
 
@@ -220,6 +222,10 @@ For more formalized details on the NSSDCA Delivery Process, see the following `p
 8.     The PDS Engineering Node Operations Team will notify you once delivery has been completed.
 
 8.  🎉 DONE
+
+.. note:: A limitation of the PDS API is that it does not provide support for a
+    collection referencing multiple versions of a product. As a result, the
+    ``pds-deep-registry-archive`` cannot support this feature either.
 
 
 .. _`pagination bug`: https://github.com/NASA-PDS/pds-api/issues/73

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,7 @@ console_scripts =
 [options.extras_require]
 dev =
     docutils            <= 0.16    # In 0.17 bullet lists aren't rendered at all with sphinx-rtd-theme
-    sphinx              == 4.2.0   # Documentation generation
+    sphinx              ~= 5.0.0   # Documentation generation
     sphinx-rtd-theme    == 0.5.0   # Documentation theme
     sphinx-argparse     == 0.2.5   # I don't think we even use this
     mypy-zope           == 1.0.5   # Type stubs for zope.interface


### PR DESCRIPTION
## 🗒️ Summary

Merge this to add a note about a limitation of the PDS API affecting what the `pds-deep-registry-archive` can produce with regard to no support for collections referencing multiple versions of a product.

Additionally, the docs did not work without an upgrade to `sphinx-5.0` as well, which is included in this PR.

## ⚙️ Test Data and/or Report

This is a documentation-only change, but the locally generated docs show the new note in the following snippet:

<img width="717" alt="Screenshot showing the new note" src="https://github.com/user-attachments/assets/9e5bce03-9f58-4581-882e-ac54c4b761e0" />


Additionally, the software tests still pass:
```
====================================== 19 passed, 16 skipped, 9 warnings in 0.97s ======================================
  py39: OK (12.38=setup[10.94]+cmd[1.44] seconds)
  congratulations :) (12.49 seconds)
```

## ♻️ Related Issues

- #203 
