### PR TITLE
Use forward `/` slashes on Windows when using PDS Registry as data source

### DIFF
--- a/src/pds2/aipgen/registry.py
+++ b/src/pds2/aipgen/registry.py
@@ -34,7 +34,7 @@ import argparse
 import dataclasses
 import hashlib
 import logging
-import os.path
+import posixpath
 import sys
 from datetime import datetime
 from http import HTTPStatus
@@ -241,7 +241,7 @@ def _comprehendregistry(url: str, bundlelidvid: str, allcollections=True) -> tup
 
 def _urltocommonpath(url: str, pathprefix: str) -> str:
     """Given a ``url`` and a ``pathprefix`` return the relative path of the path-only part of ``url``."""
-    return os.path.relpath(urlparse(url).path, pathprefix)
+    return posixpath.relpath(urlparse(url).path, pathprefix)
 
 
 def _writechecksummanifest(fn: str, pathprefix: str, bac: dict) -> tuple[str, int, int]:
@@ -361,7 +361,7 @@ def _findcommonpathprefix(bac: dict) -> str:
         for url in urls:
             yield urlparse(url).path
 
-    return os.path.commonpath(paths(urls(bac)))
+    return posixpath.commonpath(paths(urls(bac)))
 
 
 def generatedeeparchive(url: str, bundlelidvid: str, site: str, allcollections=True):


### PR DESCRIPTION
## 🗒️ Summary

Merge this to ensure `/` are used even when generating Deep Archives on Windows. Without this, you could get checksum manifest files with `\` and, worse, transfer manifest files with a _mix_ of both `/` and `\`.

## ⚙️ Test Data and/or Report

Take a look at these Windows screenshots.

### Before

<img width="1137" alt="Backslashes" src="https://github.com/user-attachments/assets/2780397a-174e-4594-8c14-c93002217b50" />
<img width="1129" alt="Worse, a mix of forward and backslashes" src="https://github.com/user-attachments/assets/4cb0ea3a-346b-45d4-99a3-4e17da6baa5c" />


### After

<img width="1137" alt="Glorious forward slashes" src="https://github.com/user-attachments/assets/c4d52de1-7706-42a5-b431-3027d6f9c0f7" />

<img width="1143" alt="And only forward slashes" src="https://github.com/user-attachments/assets/72d8324f-aeec-43f2-af5e-ecf18e7f71bc" />



## ♻️ Related Issues

- #208 

