### PR TITLE
Supports Python 3.13

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -294,7 +294,7 @@
         "filename": "tests/test_utils.py",
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_verified": false,
-        "line_number": 169,
+        "line_number": 171,
         "is_secret": false
       },
       {
@@ -302,7 +302,7 @@
         "filename": "tests/test_utils.py",
         "hashed_secret": "66ed46e8b325ac0c7982bd070c132bff14093bc3",
         "is_verified": false,
-        "line_number": 169,
+        "line_number": 171,
         "is_secret": false
       },
       {
@@ -310,10 +310,10 @@
         "filename": "tests/test_utils.py",
         "hashed_secret": "fe5c714e9a30a923a58dac84e0af313c7fb7c553",
         "is_verified": false,
-        "line_number": 179,
+        "line_number": 181,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2024-08-14T16:02:14Z"
+  "generated_at": "2025-08-21T16:23:44Z"
 }

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ Installation and Usage information can be found in the documentation online at h
 To build the Sphinx HTML documentation:
 
 ```console
-$ python3.9 -m venv venv
-$ venv/bin/python setup.py develop
-$ venv/bin/python setup.py build_sphinx
-running build_sphinx
+$ python3.13 -m venv venv
+$ source venv/bin/pip activate
+$ pip install --editable '.[dev]
+$ sphinx-build --builder html docs/source docs/build
 …
 The HTML pages are in build/sphinx/html.
 ```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,23 +34,14 @@ html_theme         = 'sphinx_rtd_theme'
 master_doc         = 'index'
 pygments_style     = 'sphinx'
 source_suffix      = '.rst'
-templates_path     = ['_templates']
 todo_include_todos = True
 
 # -- Read the docs config -------
 
 html_logo = '_static/images/PDS_Planets.png'
-
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-    ],
-}
-
+html_css_files = ['theme_overrides.css']
 html_theme_options = {
     'canonical_url': '',
-    'logo_only': False,
-    'display_version': True,
     'prev_next_buttons_location': 'bottom',
     'style_external_links': False,
     # Toc options
@@ -73,8 +64,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinx.ext.autosummary',
-    'sphinx_rtd_theme',
-    'sphinxarg.ext',
 ]
 
 # Other Options

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -6,8 +6,9 @@ build it out::
 
     git clone https://github.com/NASA-PDS/pds-deep-archive.git
     cd pds-deep-archive
-    python3.9 -m venv venv
-    venv/bin/pip install --editable '.[dev]'
+    python3.13 -m venv venv
+    source venv/bin/activate
+    pip install --editable '.[dev]'
 
 .. note:: The above series of commands assume you have the corresponding
     development tools and familiarity with invoking them from the
@@ -22,8 +23,8 @@ the code are reflected in immediately.
 
 The documentation is in ``docs/source``, formatted as reStructuredText_ and
 structured with Sphinx_.  To build the HTML from the documentation, run
-``venv/bin/python setup.py build_sphinx``. It will write HTML output to
-``build/sphinx/html``.
+``sphinx-build -b html docs/source docs/build``. It will write HTML output to
+``docs/build`` and you can open ``docs/build/index.html`` in your browser.
 
 Commits back to GitHub will trigger workflows in GitHub Actions_ that
 re-publish the project website_ as well as send artifacts to the testing_
@@ -36,16 +37,16 @@ Testing
 -------
 
 The code base finally includes unit and functional tests. Once you've run
-``venv/bin/pip install --editable '.[dev]'`` you can run the entire test suite
+``pip install --editable '.[dev]'`` you can run the entire test suite
 easily with::
 
-    venv/bin/tox -e py39
+    tox -e py313
 
 
 Making Releases
 ---------------
 
-That's what our continuous integration is for; the "stable" workflow
+That's what our continuous integration is for—the "stable" workflow.
 
 
 Contribute

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -26,7 +26,7 @@ Requirements
 Prior to installing this software, ensure your system meets the following
 requirements:
 
-•  Python_ 3. This software requires Python 3.9, 3.10, or 3.11.  Python 2 will
+•  Python_ 3. This software requires Python 3.13 or later.  Python 2 will
    absolutely *not* work, and indeed Python 2 came to its end of life on the
    first of January, 2020.  Run ``python --version``, or ``python3 --version``,
    to check what is installed.
@@ -166,47 +166,33 @@ environment for the Deep Archive software.
 To do so, open Windows PowerShell (as above) and at the prompt, type the
 following command (then press Enter)::
 
-    python3.11 -m venv pds
+    python3.13 -m venv pds
 
 .. note::
 
     If you installed Python from https://python.org/ or using Anaconda or
-    Miniconda, you may need to replace ``python3.11`` with ``python3`` or
+    Miniconda, you may need to replace ``python3.13`` with ``python3`` or
     even simply ``python``.
 
 This will create a subfolder in the current directory called ``pds`` which
 contains the virtual environment. Next, you'll need to "activate" the virtual
 environment by entering the following command (then press Enter)::
 
-    .\pds\Scripts\activate.ps1
+    .\pds\Scripts\Activate.ps1
 
 Your PowerShell prompt will change to show ``(pds)`` at the front, indicating
 that the virtual environment is now active.
-
-
-Installing LXML 4.9.0
-~~~~~~~~~~~~~~~~~~~~~
-
-Because the Deep Archive manipulates and parses XML files, the "LXML" API for
-Python must now be installed into the virtual environment. In the same
-Windows PowerShell with the ``(pds)`` prompt, enter the following command
-(then press Enter)::
-
-    pip install https://download.lfd.uci.edu/pythonlibs/archived/lxml-4.9.0-cp311-cp311-win_amd64.whl
-
-This will download and install LXML version 4.9.0 for Python 3.11 for 64-bit
-Intel/AMD processors for Windows.
 
 
 Installing PDS Deep Archive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Finally, you can install the PDS Deep Archive. As of this writing, version
-1.1.5 or later is recommended for Windows. To install it, enter the following
+1.4.0 or later is recommended for Windows. To install it, enter the following
 command in the same Windows PowerShell with the ``(pds)`` prompt (then press
 Enter)::
 
-    pip install pds.deeparchive~=1.1.5
+    pip install pds.deeparchive~=1.4.0
 
 Feel free to change the version number in the command as needed.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,19 +52,18 @@ classifiers                   =
 [options]
 install_requires =
     setuptools
-    lxml           == 4.9.0  # Must be 4.9.0 for Windows compatibility with prebuilt https://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml
+    lxml           == 6.0.0  # lxml-6.0.0-cp313-cp313-win_amd64.whl should be picked up from PyPI on Windows
     zope.component ~= 5.0.1
-    zope.interface ~= 5.4.0
+    zope.interface ~= 7.1.1
     requests       ~= 2.31.0
 # It's a bummer we can't use the "pds" namespace and have to use "pds2".
 # See https://github.com/NASA-PDS/pds-api-client/issues/7 for why.
 # 2024-02-22: Actually since dumping pds.api-client for Python Requests,
 # we could move back to "pds"!
-namespace_packages   = pds2
 zip_safe             = True
 include_package_data = True
 packages             = find_namespace:
-python_requires      = >= 3.9
+python_requires      = >= 3.13
 package_dir          =
     = src
 
@@ -92,16 +91,14 @@ console_scripts =
 
 [options.extras_require]
 dev =
-    docutils            <= 0.16    # In 0.17 bullet lists aren't rendered at all with sphinx-rtd-theme
-    sphinx              ~= 5.0.0   # Documentation generation
-    sphinx-rtd-theme    == 0.5.0   # Documentation theme
-    sphinx-argparse     == 0.2.5   # I don't think we even use this
-    mypy-zope           == 1.0.5   # Type stubs for zope.interface
-    types-pkg_resources == 0.1.3   # Type stubs for package introspection API
+    docutils            ~= 0.21    # Newer and therefore better but not so new as to make sphinx-argparse upset
+    sphinx              ~= 8.2.3   # Documentation generation
+    sphinx-rtd-theme    == 3.0.2   # Documentation theme
+    mypy-zope           == 1.0.13  # Type stubs for zope.interface
     lxml-stubs          == 0.5.1   # Type stubs for lxml, duh
-    flake8              == 3.9.2   # Unquestioning adherence to coding stylees
-    flake8-bugbear      == 21.9.1  # Ditto
-    flake8-docstrings   == 1.6.0   # And check the docstrings too
+    flake8              == 7.3.0   # Unquestioning adherence to coding stylees
+    flake8-bugbear      == 24.12.12
+    flake8-docstrings   == 1.7.0   # And check the docstrings too
     pep8-naming         == 0.12.1  # And even your function and variable names
     mypy                ~= 1.10.0  # Do your type annotations actually work?
     pydocstyle          == 6.1.1   # Do your docstrings look like everyone else's?

--- a/src/pds2/__init__.py
+++ b/src/pds2/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2019–2020 California Institute of Technology ("Caltech").
+# Copyright © 2019–2025 California Institute of Technology ("Caltech").
 # ALL RIGHTS RESERVED. U.S. Government sponsorship acknowledged.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -34,5 +34,3 @@
 # packages, the ``site-packages/pds/__init__.py`` sets the __path__ for
 # future ``pds`` resolutions. So, ``pds2``. Lovely, huh? 😬
 """PDS2 Namespace."""
-
-__import__("pkg_resources").declare_namespace(__name__)

--- a/src/pds2/aipgen/__init__.py
+++ b/src/pds2/aipgen/__init__.py
@@ -29,13 +29,13 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """PDS AIP-GEN.
 
-Okay, it's more the AIP-GEN now. It started off as Archive Information Product Generator. But then it
+Okay, it's more than AIP-GEN now. It started off as Archive Information Product Generator. But then it
 got SIP (Submission Information Product) Generation too. And then it started working beyond filesystem
 PDS products and used the registry.
 
 But ``aipgen`` is where it all started.
 """
-import pkg_resources
+import importlib.resources
 
 
-__version__ = VERSION = pkg_resources.resource_string(__name__, "VERSION.txt").decode("utf-8").strip()
+__version__ = VERSION = importlib.resources.files(__name__).joinpath("VERSION.txt").read_text().strip()

--- a/tests/base.py
+++ b/tests/base.py
@@ -30,6 +30,7 @@
 """PDS AIP-GEN test base classes."""
 import codecs
 import filecmp
+import importlib.resources
 import os
 import shutil
 import sqlite3
@@ -38,7 +39,6 @@ import unittest
 from datetime import date
 from datetime import datetime
 
-import pkg_resources
 from lxml import etree
 from pds2.aipgen.aip import process as produce_aip
 from pds2.aipgen.constants import PDS_NS_URI
@@ -64,13 +64,13 @@ class _FunctionalTestCase(unittest.TestCase):
 
     def setUp(self):
         super(_FunctionalTestCase, self).setUp()
-        bundledir = pkg_resources.resource_filename(__name__, os.path.dirname(self.getbundlefile()))
+        bundledir = importlib.resources.files(__name__).joinpath(os.path.dirname(self.getbundlefile()))
         self.dbfile = tempfile.NamedTemporaryFile()
         self.con = sqlite3.connect(self.dbfile.name)
         with self.con:
             createschema(self.con)
             comprehenddirectory(bundledir, self.con)
-        self.input = pkg_resources.resource_stream(__name__, self.getbundlefile())
+        self.input = importlib.resources.files(__name__).joinpath(self.getbundlefile()).open("rb")
         self.cwd, self.testdir = os.getcwd(), tempfile.mkdtemp()
         os.chdir(self.testdir)
         ts = datetime.utcnow()
@@ -112,7 +112,7 @@ class SIPFunctionalTestCase(_FunctionalTestCase):
     def setUp(self):
         """Set up this text fixture, duh."""
         super(SIPFunctionalTestCase, self).setUp()
-        self.valid = pkg_resources.resource_filename(__name__, self.getvalidsipfilename())
+        self.valid = importlib.resources.files(__name__).joinpath(self.getvalidsipfilename())
 
     def test_sip(self):
         """Test if a SIP manifest works as expected."""
@@ -172,8 +172,8 @@ class AIPFunctionalTestCase(_FunctionalTestCase):
     def setUp(self):
         """Set up this test fixture."""
         super(AIPFunctionalTestCase, self).setUp()
-        self.csum = pkg_resources.resource_filename(__name__, self.getmanifests()[0])
-        self.xfer = pkg_resources.resource_filename(__name__, self.getmanifests()[1])
+        self.csum = importlib.resources.files(__name__).joinpath(self.getmanifests()[0])
+        self.xfer = importlib.resources.files(__name__).joinpath(self.getmanifests()[1])
 
     def test_manifests(self):
         """See if the AIP generator makes the two manifest files."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """PDS AIP-GEN: Unit tests of the Utilities package"""
 import argparse
-import importlib.resources
 import logging
 import os
 import tempfile

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,12 +29,12 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """PDS AIP-GEN: Unit tests of the Utilities package"""
 import argparse
+import importlib.resources
 import logging
 import os
 import tempfile
 import unittest
 
-import pkg_resources
 import zope.component  # type: ignore
 from pds2.aipgen.interfaces import IURLValidator
 from pds2.aipgen.utils import addloggingarguments
@@ -77,10 +77,12 @@ class BundleParsingTestCase(unittest.TestCase):
 
     def setUp(self):
         super(BundleParsingTestCase, self).setUp()
-        self.emptyBun = pkg_resources.resource_stream(__name__, "data/ladee_test/mission_bundle/LADEE_Bundle_1101.xml")
-        self.fullBunFN = pkg_resources.resource_filename(
-            __name__, "data/ladee_test/mission_bundle/context/collection_mission_context.xml"
-        )
+        test_dir = os.path.dirname(__file__)
+        # Not even AI can figure out how to get this to work with importlib.resources.files, so back to
+        # os.path.join.
+        bundle_path = os.path.join(test_dir, "data", "ladee_test", "mission_bundle", "LADEE_Bundle_1101.xml")
+        self.emptyBun = open(bundle_path, "rb")
+        self.fullBunFN = os.path.join(test_dir, "data", "ladee_test", "mission_bundle", "context", "collection_mission_context.xml")
 
     def test_lid_vid_retrieval(self):
         liv, vid = getlogicalversionidentifier(parsexml(self.emptyBun))
@@ -125,9 +127,9 @@ class URLValidatorTest(unittest.TestCase):
         validator = zope.component.getUtility(IURLValidator)
 
         # First, try with a valid URL
-        url = "file:" + pkg_resources.resource_filename(
-            __name__, "data/ladee_test/mission_bundle/context/collection_mission_context.xml"
-        )
+        test_dir = os.path.dirname(__file__)
+        context_path = os.path.join(test_dir, "data", "ladee_test", "mission_bundle", "context", "collection_mission_context.xml")
+        url = "file:" + context_path
         self.assertTrue(not self.singleton._checked)
         validator.validate(url)
         self.assertTrue(self.singleton._checked)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, docs, lint
+envlist = py313, docs, lint
 isolated_build = True
 
 [testenv]
@@ -10,7 +10,7 @@ commands = pytest
 [testenv:docs]
 deps = .[dev]
 whitelist_externals = python
-commands = python setup.py build_sphinx
+commands = sphinx-build -b html docs/source docs/build
 
 [testenv:lint]
 deps = pre-commit
@@ -19,6 +19,6 @@ commands=
 skip_install = true
 
 [testenv:dev]
-basepython = python3.9
+basepython = python3.13
 usedevelop = True
 deps = .[dev]


### PR DESCRIPTION
## 🗒️ Summary

Merge this for Python 3.13 support.

## ⚙️ Test Data and/or Report

The testing procedure is broken into separate sections.

### Developer Tests

When installing as `pip install --editable '.[dev]'` and running `tox`:
```
Check that executables have shebangs.................(no files to check)Skipped
Check for merge conflicts................................................Passed
Debug Statements (Python)................................................Passed
Check Yaml...............................................................Passed
Reorder python imports...................................................Passed
mypy.....................................................................Passed
flake8...................................................................Passed
Detect secrets...........................................................Passed
  py313: OK (12.93=setup[11.78]+cmd[1.14] seconds)
  docs: OK (11.19=setup[10.25]+cmd[0.94] seconds)
  lint: OK (5.65=setup[1.22]+cmd[4.43] seconds)
  congratulations :) (29.83 seconds)
```

### Unix Tests

Running the two main commands on Unix (macOS in this case):
```
$ ls *.tab *.xml
/bin/ls: No match.
$ .v/bin/pds-deep-archive --site PDS_ATM --disable-url-validation --bundle-base-url https://atmos.nmsu.edu/ test/data/ladee_test/mission_bundle/LADEE_Bundle_1101.xml 
INFO 👟 PDS Deep Archive, version 1.4.0
WARNING 👀 Cannot parse XML document at «/Users/kelly/Documents/Clients/JPL/PDS/Development/nasa-pds/deep-archive/test/data/ladee_test/mission_bundle/xml_schema/empty.xml»; ignoring it
INFO 🏃‍♀️ Starting AIP generation for test/data/ladee_test/mission_bundle/LADEE_Bundle_1101.xml
INFO 🎉 Success! AIP done, files generated:
INFO 📄 Checksum manifest: ladee_mission_bundle_v1.0_20250821_checksum_manifest_v1.0.tab
INFO 📄 Transfer manifest: ladee_mission_bundle_v1.0_20250821_transfer_manifest_v1.0.tab
INFO 📄 XML label for them both: ladee_mission_bundle_v1.0_20250821_aip_v1.0.xml
INFO 🏃‍♀️ Starting SIP generation for test/data/ladee_test/mission_bundle/LADEE_Bundle_1101.xml
INFO 🎉 Success! From /Users/kelly/Documents/Clients/JPL/PDS/Development/nasa-pds/deep-archive/test/data/ladee_test/mission_bundle/LADEE_Bundle_1101.xml, generated these output files:
INFO 📄 SIP Manifest: ladee_mission_bundle_v1.0_20250821_sip_v1.0.tab
INFO 📄 XML label for the SIP: ladee_mission_bundle_v1.0_20250821_sip_v1.0.xml
INFO 👋 That's it for now. Bye.
$ ls *.tab *.xml
ladee_mission_bundle_v1.0_20250821_aip_v1.0.xml
ladee_mission_bundle_v1.0_20250821_checksum_manifest_v1.0.tab
ladee_mission_bundle_v1.0_20250821_sip_v1.0.tab
ladee_mission_bundle_v1.0_20250821_sip_v1.0.xml
ladee_mission_bundle_v1.0_20250821_transfer_manifest_v1.0.tab
$ rm *.tab *.xml
$ .v/bin/pds-deep-registry-archive --site PDS_GEO urn:nasa:pds:magellan_gxdr::1.0
INFO 👟 PDS Deep Registry-based Archive, version 1.4.0
INFO 📄 Wrote AIP checksum manifest magellan_gxdr_v1.0_20250821_checksum_manifest_v1.0.tab with 109 entries
INFO 📄 Wrote AIP transfer manifest magellan_gxdr_v1.0_20250821_transfer_manifest_v1.0.tab with 109 entries
INFO 📄 Wrote label for them both: magellan_gxdr_v1.0_20250821_aip_v1.0.xml
INFO 📄 Wrote SIP magellan_gxdr_v1.0_20250821_sip_v1.0.tab with 109 entries
INFO 📄 Wrote label for SIP: magellan_gxdr_v1.0_20250821_sip_v1.0.xml
INFO 👋 Thanks for using this program! Bye!
$ ls *.tab *.xml
magellan_gxdr_v1.0_20250821_aip_v1.0.xml                magellan_gxdr_v1.0_20250821_sip_v1.0.xml
magellan_gxdr_v1.0_20250821_checksum_manifest_v1.0.tab  magellan_gxdr_v1.0_20250821_transfer_manifest_v1.0.tab
magellan_gxdr_v1.0_20250821_sip_v1.0.tab
```

### Windows Tests

First, using the local filesystem:

<img width="1129" height="904" alt="Screenshot from Windows for pds-deep-archive" src="https://github.com/user-attachments/assets/2adb2b9b-6e06-47f8-9441-f793c003c225" />

And now using the Registry:

<img width="1133" height="757" alt="Screenshot from Windows for pds-deep-registry-archive" src="https://github.com/user-attachments/assets/568f9823-8489-4208-a47d-6f4bbef6231d" />



## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/105