### PR TITLE
Add coverage reports and uploading of them to SonarQube Cloud

### DIFF
--- a/.github/workflows/branch-cicd.yml
+++ b/.github/workflows/branch-cicd.yml
@@ -55,11 +55,14 @@ jobs:
                     key: pds-${{runner.os}}-py-${{hashFiles('**/*.whl')}}
                     # To restore a set of files, we only need to match a prefix of the saved key.
                     restore-keys: pds-${{runner.os}}-py-
-
             -
                 name: 🩺 Test Software
                 run:
                     pip install --editable '.[dev]'
-
                     tox
                 shell: bash
+            -
+                name: 🛏️ Upload Coverage
+                uses: SonarSource/sonarqube-scan-action@v5
+                with:
+                    SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ pip-selfcheck.json
 .coverage
 htmlcov
 .tox/
+coverage.xml
 
 # Object files
 *.o

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,3 @@
+sonar.projectKey=NASA-PDS_deep-archive
+sonar.organization=nasa-pds
+sonar.python.coverage.reportPaths=coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,42 @@
 [tox]
 envlist = py313, docs, lint
-isolated_build = True
+requires = tox>=4.6
 
 [testenv]
-deps = .[dev]
-whitelist_externals = pytest
-commands = pytest
+description = run tests
+basepython = python3.13
+package = wheel
+extras = dev
+usedevelop = true
+commands = pytest --cov=src --cov-report=xml {posargs}
 
 [testenv:docs]
-deps = .[dev]
-whitelist_externals = python
+description = build docs
+extras = dev
 commands = sphinx-build -b html docs/source docs/build
 
 [testenv:lint]
-deps = pre-commit
-commands=
-    python -m pre_commit run --color=always {posargs:--all}
+description = run linters
 skip_install = true
+deps = pre-commit
+commands = python -m pre_commit run --color=always {posargs:--all}
 
-[testenv:dev]
-basepython = python3.13
-usedevelop = True
-deps = .[dev]
+[coverage:run]
+source = src
+omit =
+    */tests/*
+    */test_*
+    */__pycache__/*
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
+    class .*\bProtocol\):
+    @(abc\.)?abstractmethod


### PR DESCRIPTION
## 🗒️ Summary

Merge this to modify the branch CI/CD workflow to:

- Add coverage report generation to the `tox` step
- Upload those reports to SonarQube Cloud using the org-level `SONAR_TOKEN` secret

## ⚙️ Test Data and/or Report

The report generation works fine; see some of the generated `coverage.xml`:
```xml
<?xml version="1.0" ?>
<coverage version="5.5" timestamp="1758040364614" lines-valid="882" lines-covered="556" line-rate="0.6304" branches-covered="0" branches-valid="0" branch-rate="0" complexity="0">
	<!-- Generated by coverage.py: https://coverage.readthedocs.io -->
	<!-- Based on https://raw.githubusercontent.com/cobertura/web/master/htdocs/xml/coverage-04.dtd -->
	<sources>
		<source>…/nasa-pds/deep-archive/src</source>
	</sources>
	<packages>
		<package name="pds2" line-rate="0.5" branch-rate="0" complexity="0">
			<classes>
				<class name="__init__.py" filename="pds2/__init__.py" complexity="0" line-rate="0.5" branch-rate="0">
					<methods/>
					<lines>
						<line number="0" hits="0"/>
						<line number="36" hits="1"/>
…
```

Testing the upload feature requires GitHub Actions.


## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/104