### PR TITLE
Move uploading of the coverage report from branch CICD to merges-to-main

### DIFF
--- a/.github/workflows/branch-cicd.yml
+++ b/.github/workflows/branch-cicd.yml
@@ -61,8 +61,3 @@ jobs:
                     pip install --editable '.[dev]'
                     tox
                 shell: bash
-            -
-                name: 🛏️ Upload Coverage
-                uses: SonarSource/sonarqube-scan-action@v5
-                env:
-                    SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -77,6 +77,11 @@ jobs:
                     pypi_username: ${{secrets.TEST_PYPI_USERNAME}}
                     pypi_password: ${{secrets.TEST_PYPI_PASSWORD}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
+            -
+                name: 🛏️ Upload Coverage
+                uses: SonarSource/sonarqube-scan-action@v5
+                env:
+                    SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
 
 ...
 


### PR DESCRIPTION
## 🗒️ Summary

Based on [this comment](https://github.com/NASA-PDS/deep-archive/pull/216#issuecomment-3300023137) we're moving the uploading of the coverage report to SonarQube Cloud from the branch workflow to the unstable workflow; the idea is that coverage reports are more interesting on `main` than on in-dev branches.

## ⚙️ Test Data and/or Report

N/A.

## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/104