### PR TITLE
Fix MD5 hashing to support FIPS mode

### DIFF
--- a/src/pds2/aipgen/aip.py
+++ b/src/pds2/aipgen/aip.py
@@ -288,7 +288,7 @@ def _writechecksummanifest(chksumfn, lid, vid, con, prefixlen, allcollections):
     by lid-only if True, otherwise the latest version only if False.
     """
     _logger.debug("🧾 Writing checksum manifest for %s::%s to %s", lid, vid, chksumfn)
-    md5, size, count = hashlib.new("md5"), 0, 0
+    md5, size, count = hashlib.new("md5", usedforsecurity=False), 0, 0
     files = _getfiles(con, lid, vid, allcollections)
     with open(chksumfn, "wb") as o:
         # The tuples are (lid, vid, filepath)—we care just about filepath
@@ -314,7 +314,7 @@ def _writetransfermanifest(xferfn, prefixlen, files):
     (lid, vid, filepath).
     """
     _logger.debug("🚢 Writing transfer manifest to %s", xferfn)
-    md5, size, count = hashlib.new("md5"), 0, 0
+    md5, size, count = hashlib.new("md5", usedforsecurity=False), 0, 0
 
     # First, organize by lid::vids → sequences of files
     lidvidstofiles = {}

--- a/src/pds2/aipgen/registry.py
+++ b/src/pds2/aipgen/registry.py
@@ -251,7 +251,7 @@ def _writechecksummanifest(fn: str, pathprefix: str, bac: dict) -> tuple[str, in
     off paths, and using information from the ``bac``.  Return a triple of the MD5
     of the manifest, its size in bytes, and a count of the number of entries in it.
     """
-    hashish, size, count = hashlib.new("md5"), 0, 0
+    hashish, size, count = hashlib.new("md5", usedforsecurity=False), 0, 0
     with open(fn, "wb") as o:
         for files in bac.values():
             for f in files:
@@ -274,7 +274,7 @@ def _writetransfermanifest(fn: str, pathprefix: str, bac: dict) -> tuple[str, in
     the MD5 of the created manifest, its size in bytes, and a count of its entries.
     """
     _logger.debug("⚙️ Writing AIP transfer manifest to %s", fn)
-    hashish, size, count = hashlib.new("md5"), 0, 0
+    hashish, size, count = hashlib.new("md5", usedforsecurity=False), 0, 0
     with open(fn, "wb") as o:
         for lidvid, files in bac.items():
             for f in files:
@@ -321,7 +321,7 @@ def _writesip(bundlelidvid: str, bac: dict, title: str, site: str, ts: datetime,
     """
     _logger.debug("⚙️ Creating SIP for %s (title %s) for site %s", bundlelidvid, title, site)
     sipfn = _makefilename(bundlelidvid, ts, "sip", PDS_TABLE_FILENAME_EXTENSION)
-    hashish, size, count = hashlib.new("md5"), 0, 0
+    hashish, size, count = hashlib.new("md5", usedforsecurity=False), 0, 0
     with open(sipfn, "wb") as o:
         for lidvid, files in bac.items():
             for f in files:

--- a/src/pds2/aipgen/sip.py
+++ b/src/pds2/aipgen/sip.py
@@ -152,7 +152,7 @@ def _writetable(hashedfiles, hashname, manifest, baseurl, bp):
     written.  ``bp`` is the base path that'll get stripped from URLs before writing.
     """
     _logger.debug("⎍ Writing SIP table with hash %s", hashname)
-    hashish, size, hashname, count, bp = hashlib.new("md5"), 0, hashname.upper(), 0, bp.replace("\\", "/")
+    hashish, size, hashname, count, bp = hashlib.new("md5", usedforsecurity=False), 0, hashname.upper(), 0, bp.replace("\\", "/")
     for url, digest, lidvid in sorted(hashedfiles):
         if baseurl.endswith("/"):
             baseurl = baseurl[:-1]

--- a/src/pds2/aipgen/utils.py
+++ b/src/pds2/aipgen/utils.py
@@ -244,7 +244,8 @@ def parsexml(f):
 @functools.lru_cache(maxsize=_digestcachesize)
 def getdigest(url, hashname):
     """Compute a digest of the object at url and return it as a hex string."""
-    hashish = hashlib.new(hashname)
+    # Use usedforsecurity=False for MD5 to support FIPS mode (checksums, not crypto)
+    hashish = hashlib.new(hashname, usedforsecurity=False) if hashname.lower() == 'md5' else hashlib.new(hashname)
     _logger.debug("Getting «%s» for hashing with %s", url, hashname)
     with urllib.request.urlopen(url) as i:
         while True:
@@ -257,7 +258,7 @@ def getdigest(url, hashname):
 
 def getmd5(i):
     """Compute an MD5 digest of the input stream ``i`` and return it as a hex string."""
-    md5 = hashlib.new("md5")
+    md5 = hashlib.new("md5", usedforsecurity=False)
     while True:
         buf = i.read(_bufsiz)
         if len(buf) == 0:


### PR DESCRIPTION
## Summary

This PR fixes issue #226 by adding the `usedforsecurity=False` parameter to all MD5 hashing calls, allowing the deep-archive tools to work on FIPS-enabled systems.

## Problem

On FIPS-enabled systems (common in government/enterprise environments), MD5 hashing is disabled by default because it's not considered cryptographically secure. This causes `pds-deep-archive` and `pds-deep-registry-archive` to fail with:

```
ValueError: unsupported hash type md5(in FIPS mode)
```

## Solution

Since MD5 is used in this codebase for **data integrity checksums** (not cryptographic security), we can safely use the `usedforsecurity=False` parameter introduced in Python 3.9+. This parameter explicitly tells the system that MD5 is being used for non-security purposes, which is allowed even in FIPS mode.

## Changes

Updated all MD5 hashing calls in:
- `src/pds2/aipgen/aip.py` (2 occurrences)
- `src/pds2/aipgen/registry.py` (3 occurrences)  
- `src/pds2/aipgen/sip.py` (1 occurrence)
- `src/pds2/aipgen/utils.py` (2 functions: `getmd5()` and `getdigest()`)

## Testing

- All hashlib-related unit tests pass (`test_getdigest`, `test_getmd5`)
- Verified MD5 with `usedforsecurity=False` works correctly
- Pre-commit hooks (mypy, flake8) pass
- Note: Some functional tests were failing before and after this change due to pre-existing test infrastructure issues unrelated to this fix

## Compatibility

- Requires Python 3.9+ (already a requirement per `setup.cfg`)
- The `usedforsecurity` parameter was added in Python 3.9
- Current package requires Python 3.12+, so this is fully compatible

Fixes #226